### PR TITLE
feat: Implement prompt navigation and new page UI

### DIFF
--- a/frontend/src/app/components/Navbar.tsx
+++ b/frontend/src/app/components/Navbar.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import Link from "next/link";
+import { Sparkles } from "lucide-react"; // Using Sparkles as a placeholder logo icon
+
+const Navbar = () => {
+    return (
+        <nav className="bg-black/30 backdrop-blur-md shadow-lg sticky top-0 z-50 w-full font-geist">
+            <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+                <div className="flex items-center justify-between h-16">
+                    <div className="flex items-center">
+                        <Link href="/" className="flex items-center text-white hover:text-purple-400 transition-colors">
+                            <Sparkles className="h-8 w-8 mr-2 text-purple-500" />
+                            <span className="font-semibold text-xl">Scafold AI</span>
+                        </Link>
+                    </div>
+                    <div className="hidden md:block">
+                        <div className="ml-10 flex items-baseline space-x-4">
+                            <Link
+                                href="/docs"
+                                className="text-gray-300 hover:bg-gray-700 hover:text-white px-3 py-2 rounded-md text-sm font-medium transition-colors"
+                            >
+                                Docs
+                            </Link>
+                            <Link
+                                href="/pricing"
+                                className="text-gray-300 hover:bg-gray-700 hover:text-white px-3 py-2 rounded-md text-sm font-medium transition-colors"
+                            >
+                                Pricing
+                            </Link>
+                            <Link
+                                href="/contact"
+                                className="text-gray-300 hover:bg-gray-700 hover:text-white px-3 py-2 rounded-md text-sm font-medium transition-colors"
+                            >
+                                Contact
+                            </Link>
+                        </div>
+                    </div>
+                    <div className="md:hidden">
+                        {/* Mobile menu button (optional, for future enhancement) */}
+                        {/* <button className="text-gray-300 hover:text-white focus:outline-none focus:text-white">
+                            <svg className="h-6 w-6" stroke="currentColor" fill="none" viewBox="0 0 24 24">
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 6h16M4 12h16m-7 6h7" />
+                            </svg>
+                        </button> */}
+                    </div>
+                </div>
+            </div>
+        </nav>
+    );
+};
+
+export default Navbar;

--- a/frontend/src/app/elements/hero.tsx
+++ b/frontend/src/app/elements/hero.tsx
@@ -1,21 +1,26 @@
 "use client";
-import React, { useState, FormEvent } from "react"; // Import FormEvent
+import React, { useState, FormEvent } from "react";
+import { useRouter } from "next/navigation"; // Import useRouter
 import AnimatedBackground from "@/app/ui/background";
-import { ArrowRight, Sparkles } from "lucide-react";
+import { Sparkles } from "lucide-react";
 
 const Hero = () => {
     const [prompt, setPrompt] = useState<string>("");
+    const router = useRouter(); // Initialize useRouter
 
     function handleSubmit(e: FormEvent) {
-        // Add type for the event object
-        e.preventDefault(); // Prevent default form submission behavior
+        e.preventDefault();
 
         if (!prompt.trim()) {
+            // Optionally, provide user feedback here (e.g., set an error state)
             console.log("Prompt is empty or just whitespace.");
             return;
         }
-        console.log("Prompt submitted:", prompt);
-        setPrompt(""); // Clear the input after submission
+        // Navigate to the new page with the prompt as a query parameter
+        router.push(`/prompt-display?prompt=${encodeURIComponent(prompt)}`);
+        // It's generally better not to clear the prompt here,
+        // in case the user wants to quickly modify and resubmit from the new page (though current setup doesn't support that directly)
+        // setPrompt("");
     }
 
     return (

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -24,6 +24,8 @@ export const metadata: Metadata = {
         "Scaffold AI is a platform for generating project structures with ease and speed.",
 };
 
+import Navbar from "./components/Navbar"; // Import the Navbar component
+
 export default function RootLayout({
     children,
 }: Readonly<{
@@ -34,6 +36,7 @@ export default function RootLayout({
             <body
                 className={`${ibmPlexSans.variable} ${playfairDisplay.variable} ${geist.variable} antialiased bg-black text-white min-h-screen relative overflow-x-hidden`}
             >
+                <Navbar /> {/* Add the Navbar here */}
                 {/* Content wrapper */}
                 <div className="relative z-10 p-4">
                     <main className="relative">{children}</main>

--- a/frontend/src/app/prompt-display/page.tsx
+++ b/frontend/src/app/prompt-display/page.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import React, { Suspense } from "react"; // Import Suspense
+import { useSearchParams } from "next/navigation";
+import { Terminal, Brain, MessageSquareText } from "lucide-react";
+
+// A separate component to handle search params, allowing Suspense boundary
+const PromptDisplayContent = () => {
+    const searchParams = useSearchParams();
+    const prompt = searchParams.get("prompt");
+
+    return (
+        <div className="min-h-screen bg-gradient-to-br from-gray-900 via-black to-gray-900 text-white font-geist py-12 px-4 sm:px-6 lg:px-8">
+            <div className="max-w-4xl mx-auto">
+                {/* Prompt Display Section */}
+                <div className="bg-white/5 backdrop-blur-lg rounded-xl shadow-2xl p-6 md:p-8 mb-12">
+                    <div className="flex items-center mb-4">
+                        <MessageSquareText className="h-8 w-8 text-purple-400 mr-3" />
+                        <h1 className="text-3xl font-bold text-transparent bg-clip-text bg-gradient-to-r from-purple-400 to-pink-500">
+                            Your Prompt
+                        </h1>
+                    </div>
+                    {prompt ? (
+                        <p className="text-lg text-gray-300 leading-relaxed">
+                            {prompt}
+                        </p>
+                    ) : (
+                        <p className="text-lg text-gray-500">
+                            No prompt provided. Try entering one on the home page!
+                        </p>
+                    )}
+                </div>
+
+                {/* Placeholder for FastAPI Backend Response */}
+                <div className="bg-white/5 backdrop-blur-lg rounded-xl shadow-2xl p-6 md:p-8">
+                    <div className="flex items-center mb-6">
+                        <Brain className="h-8 w-8 text-green-400 mr-3" />
+                        <h2 className="text-2xl font-semibold text-transparent bg-clip-text bg-gradient-to-r from-green-400 to-blue-500">
+                            AI Generated Structure
+                        </h2>
+                    </div>
+                    <div className="bg-black/50 p-6 rounded-lg min-h-[200px] flex items-center justify-center">
+                        <div className="text-center">
+                            <Terminal className="h-12 w-12 text-gray-600 mx-auto mb-4" />
+                            <p className="text-gray-500 text-lg">
+                                Future AI response will appear here...
+                            </p>
+                            <p className="text-gray-600 text-sm mt-1">
+                                (This is where the generated file structure or code snippets will be shown)
+                            </p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+// The actual page component that uses Suspense
+const PromptPage = () => {
+    return (
+        <Suspense fallback={<div className="flex justify-center items-center min-h-screen text-white">Loading prompt...</div>}>
+            <PromptDisplayContent />
+        </Suspense>
+    );
+};
+
+export default PromptPage;


### PR DESCRIPTION
- Add Navbar component and integrate into layout.
- Create a new page /prompt-display to show the entered prompt.
- Implement navigation from hero section to the new page, passing the prompt as a query parameter.
- Style the new page and navbar for visual appeal.
- Ensure prompt is correctly displayed on the new page.