### PR TITLE
feat: Implement initial community templates page

### DIFF
--- a/frontend/src/app/components/Navbar.tsx
+++ b/frontend/src/app/components/Navbar.tsx
@@ -17,6 +17,12 @@ const Navbar = () => {
                     <div className="hidden md:block">
                         <div className="ml-10 flex items-baseline space-x-4">
                             <Link
+                                href="/templates"
+                                className="text-gray-300 hover:bg-gray-700 hover:text-white px-3 py-2 rounded-md text-sm font-medium transition-colors"
+                            >
+                                Templates
+                            </Link>
+                            <Link
                                 href="/docs"
                                 className="text-gray-300 hover:bg-gray-700 hover:text-white px-3 py-2 rounded-md text-sm font-medium transition-colors"
                             >

--- a/frontend/src/app/components/TemplateCard.tsx
+++ b/frontend/src/app/components/TemplateCard.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { CommunityTemplate } from '@/types'; // Assuming @ is configured for src path
+import { ExternalLink, Briefcase, Users, Tag, Palette, FileText, Terminal } from 'lucide-react'; // Example icons
+
+interface TemplateCardProps {
+  template: CommunityTemplate;
+}
+
+const TemplateCard: React.FC<TemplateCardProps> = ({ template }) => {
+  return (
+    <div className="bg-gray-800/50 backdrop-blur-md shadow-xl rounded-lg overflow-hidden transform transition-all hover:scale-105 hover:shadow-purple-500/30 duration-300 ease-in-out h-full flex flex-col">
+      {template.imageUrl && (
+        <img
+          src={template.imageUrl}
+          alt={`${template.title} preview`}
+          className="w-full h-48 object-cover"
+          onError={(e) => {
+            // Fallback if image fails to load, e.g., hide or show placeholder
+            (e.target as HTMLImageElement).style.display = 'none';
+          }}
+        />
+      )}
+      {!template.imageUrl && (
+        <div className="w-full h-48 bg-gradient-to-br from-purple-600 to-blue-500 flex items-center justify-center">
+          <FileText size={48} className="text-white opacity-50" />
+        </div>
+      )}
+
+      <div className="p-6 flex flex-col flex-grow">
+        <h3 className="text-2xl font-semibold mb-2 text-purple-300">{template.title}</h3>
+        <p className="text-gray-400 text-sm mb-4 flex-grow">{template.description}</p>
+
+        <div className="mb-4">
+          <div className="flex items-center text-xs text-gray-500 mb-1">
+            <Users size={14} className="mr-2 text-purple-400" />
+            <span>Author: {template.author} (v{template.version})</span>
+          </div>
+          {template.githubUrl && (
+            <a
+              href={template.githubUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-xs text-purple-400 hover:text-purple-300 flex items-center transition-colors"
+            >
+              <ExternalLink size={14} className="mr-1" />
+              View on GitHub
+            </a>
+          )}
+        </div>
+
+        <div className="mb-4">
+          {template.frameworks && template.frameworks.length > 0 && (
+            <div className="flex items-center text-xs text-gray-400 mb-1">
+              <Briefcase size={14} className="mr-2 text-purple-400" />
+              Frameworks: {template.frameworks.join(', ')}
+            </div>
+          )}
+          {template.technologies && template.technologies.length > 0 && (
+             <div className="flex items-center text-xs text-gray-400">
+               <Palette size={14} className="mr-2 text-purple-400" />
+               <span>Technologies: {template.technologies.join(', ')}</span>
+             </div>
+          )}
+        </div>
+
+        {template.tags && template.tags.length > 0 && (
+          <div className="mb-4">
+            <div className="flex items-center text-xs text-gray-500 mb-1">
+                <Tag size={14} className="mr-2 text-purple-400" />
+                Tags:
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {template.tags.map((tag) => (
+                <span
+                  key={tag}
+                  className="px-2 py-1 bg-gray-700 text-purple-300 rounded-full text-xs"
+                >
+                  {tag}
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+
+      <div className="p-6 bg-gray-800/30 border-t border-gray-700/50">
+        {/* Placeholder for action button, e.g., "Use Template" or "View Details" */}
+        <button className="w-full bg-purple-600 hover:bg-purple-700 text-white font-semibold py-2 px-4 rounded-lg transition-colors duration-150 flex items-center justify-center">
+          <Terminal size={16} className="mr-2" />
+          Use Template
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default TemplateCard;

--- a/frontend/src/app/templates/mock-data.ts
+++ b/frontend/src/app/templates/mock-data.ts
@@ -1,0 +1,85 @@
+import { CommunityTemplate } from '@/types'; // Assuming @ is configured for src path
+
+export const mockTemplates: CommunityTemplate[] = [
+  {
+    id: 'nextjs-blog-tailwind',
+    title: 'Next.js Blog with Tailwind CSS',
+    description: 'A simple, clean blog template built with Next.js and styled with Tailwind CSS. Perfect for getting started quickly.',
+    author: 'AI Engineer',
+    tags: ['Next.js', 'Tailwind CSS', 'Blog', 'Frontend'],
+    frameworks: ['Next.js'],
+    technologies: ['React', 'TypeScript', 'Tailwind CSS', 'Markdown'],
+    fileStructurePreview: `
+├── public/
+│   └── next.svg
+├── src/
+│   ├── app/
+│   │   ├── layout.tsx
+│   │   └── page.tsx
+│   ├── components/
+│   │   └── PostPreview.tsx
+│   └── posts/
+│       └── example-post.md
+├── next.config.js
+└── package.json
+    `,
+    usageInstructions: 'Run `npm install && npm run dev`. Create new blog posts as markdown files in the `src/posts` directory.',
+    imageUrl: 'https://via.placeholder.com/400x250/0070f3/ffffff?text=Next.js+Blog', // Placeholder image
+    githubUrl: 'https://github.com/vercel/next-learn/tree/main/basics/learn-starter', // Example link
+    version: '1.0.0',
+  },
+  {
+    id: 'fastapi-auth-postgres',
+    title: 'FastAPI Backend with Auth & Postgres',
+    description: 'A robust FastAPI backend setup including JWT authentication, SQLAlchemy for ORM, and PostgreSQL database integration.',
+    author: 'Backend Pro',
+    tags: ['FastAPI', 'Python', 'Backend', 'Authentication', 'PostgreSQL', 'SQLAlchemy'],
+    frameworks: ['FastAPI'],
+    technologies: ['Python', 'PostgreSQL', 'SQLAlchemy', 'JWT', 'Docker'],
+    fileStructurePreview: `
+├── app/
+│   ├── __init__.py
+│   ├── main.py
+│   ├── crud.py
+│   ├── database.py
+│   ├── models.py
+│   ├── schemas.py
+│   └── security.py
+├── tests/
+├── alembic/
+├── .env.example
+├── Dockerfile
+├── requirements.txt
+└── README.md
+    `,
+    usageInstructions: 'Setup your .env file based on .env.example. Run `docker-compose up --build` to start the service. API documentation available at /docs.',
+    imageUrl: 'https://via.placeholder.com/400x250/009688/ffffff?text=FastAPI+Backend', // Placeholder image
+    version: '1.1.0',
+  },
+  {
+    id: 'express-typescript-starter',
+    title: 'Express.js TypeScript Starter',
+    description: 'A basic starter project for building REST APIs with Express.js and TypeScript, including ESLint and Prettier setup.',
+    author: 'Node Dev',
+    tags: ['Express.js', 'Node.js', 'TypeScript', 'Backend', 'API'],
+    frameworks: ['Express.js'],
+    technologies: ['Node.js', 'TypeScript', 'ESLint', 'Prettier'],
+    fileStructurePreview: `
+├── src/
+│   ├── controllers/
+│   ├── routes/
+│   ├── services/
+│   ├── app.ts
+│   └── server.ts
+├── .env
+├── .eslintrc.js
+├── .prettierrc.js
+├── package.json
+└── tsconfig.json
+    `,
+    usageInstructions: 'Run `npm install` then `npm run dev`. API endpoints are defined in `src/routes`.',
+    imageUrl: 'https://via.placeholder.com/400x250/68A063/ffffff?text=Express+TS', // Placeholder image
+    githubUrl: 'https://github.com/Microsoft/TypeScript-Node-Starter', // Example link
+    version: '0.9.0',
+  },
+];

--- a/frontend/src/app/templates/page.tsx
+++ b/frontend/src/app/templates/page.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import Navbar from '@/app/components/Navbar'; // Assuming @ is path alias for ./src
+import TemplateCard from '@/app/components/TemplateCard'; // Import the TemplateCard component
+import { mockTemplates } from './mock-data'; // Import the mock data
+
+const TemplatesPage = () => {
+  return (
+    <div className="flex flex-col min-h-screen bg-black text-white font-geist">
+      <Navbar />
+      <main className="flex-grow container mx-auto px-4 py-8">
+        <h1 className="text-4xl font-bold mb-8 text-center text-purple-400">
+          Community Templates
+        </h1>
+        <p className="text-lg text-gray-300 mb-12 text-center">
+          Browse and use templates shared by the Scafold AI community.
+        </p>
+        {/* Template cards will be rendered here */}
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+          {mockTemplates.map((template) => (
+            <TemplateCard key={template.id} template={template} />
+          ))}
+        </div>
+      </main>
+      <footer className="py-8 bg-gray-900/50 text-center text-gray-500 mt-12">
+        <p>
+          &copy; {new Date().getFullYear()} Scafold AI. All rights
+          reserved.
+        </p>
+        {/* Consider adding social links or other footer content here, similar to the main page */}
+      </footer>
+    </div>
+  );
+};
+
+export default TemplatesPage;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,0 +1,14 @@
+export interface CommunityTemplate {
+  id: string;
+  title: string;
+  description: string;
+  author: string;
+  tags: string[];
+  frameworks: string[];
+  technologies: string[];
+  fileStructurePreview: string; // Could be a simple text tree or a more complex structure later
+  usageInstructions: string;
+  imageUrl?: string; // Optional image for the template card
+  githubUrl?: string; // Optional link to a GitHub repository for the template
+  version: string;
+}


### PR DESCRIPTION
- Add a new route `/templates` to display community-provided templates.
- Define a `CommunityTemplate` interface for template data structure.
- Create mock data for initial display of templates.
- Develop a `TemplateCard` component to render individual template information.
- Integrate `TemplateCard` into the `/templates` page with a responsive grid layout.
- Add a 'Templates' link to the main navigation bar.
- Style components using Tailwind CSS consistent with the existing design.